### PR TITLE
Add PDF build workflow

### DIFF
--- a/.github/workflows/build_pdfs.yml
+++ b/.github/workflows/build_pdfs.yml
@@ -1,0 +1,25 @@
+name: Build PDFs
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'weeks/**/*.md'
+      - '.github/workflows/build_pdfs.yml'
+      - 'scripts/build_pdfs.sh'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+      - name: Build PDFs
+        run: bash scripts/build_pdfs.sh
+      - name: Upload PDFs
+        uses: actions/upload-artifact@v3
+        with:
+          name: worksheets-pdf
+          path: weeks/**/*.pdf

--- a/TODO.md
+++ b/TODO.md
@@ -244,9 +244,9 @@
 - [ ] [P2] Set up linting for notebooks and scripts.
   - [ ] Configure flake8 for Python style
   - [ ] Add notebook-specific linting rules
-- [ ] [P3] Add build scripts for converting source files to PDFs.
-  - [ ] Markdown to PDF conversion pipeline
-  - [ ] Batch processing for all worksheets
+- [x] [P3] Add build scripts for converting source files to PDFs. (2025-06-17)
+  - [x] Markdown to PDF conversion pipeline (2025-06-17)
+  - [x] Batch processing for all worksheets (2025-06-17)
 - [ ] [P2] Configure GitHub Actions to run notebook execution tests.
   - [ ] Test all notebooks run without errors
   - [ ] Verify output matches expected results

--- a/scripts/build_pdfs.sh
+++ b/scripts/build_pdfs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Convert worksheet and answer markdown files to PDF using pandoc
+# Output PDFs are placed alongside their source files.
+
+find weeks \( -name 'W*_Day*_Sheet.md' -o -name 'W*_Day*_Answers.md' \) -print0 \
+  | while IFS= read -r -d '' md_file; do
+    pdf_file="${md_file%.md}.pdf"
+    echo "Converting $md_file -> $pdf_file"
+    pandoc "$md_file" -o "$pdf_file"
+done


### PR DESCRIPTION
## Summary
- add script for converting worksheet Markdown files to PDFs
- create GitHub Actions workflow to run the script
- mark PDF build tasks as complete in TODO

## Testing
- `bash scripts/build_pdfs.sh` *(fails: `pandoc` not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ef1436c648320bd1d666c5fda5016